### PR TITLE
Fix broken GitHub URLs on static site

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -81,12 +81,12 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
-          editUrl: 'https://github.com/lucialand/lucia-docs/edit/master/',
+          editUrl: 'https://github.com/lucialand/lucia-docs/edit/main/',
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
-          editUrl: 'https://github.com/lucialand/lucia-docs/edit/master/blog/',
+          editUrl: 'https://github.com/lucialand/lucia-docs/edit/main/blog/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
Since changing the default branch from master to main, the `edit this page` links are broken:

Currently is: 
`https://github.com/lucialand/lucia-docs/edit/master/docs/simpleClickerGame.md`

Should be: 
`https://github.com/lucialand/lucia-docs/edit/main/docs/simpleClickerGame.md`


This PR updates the docusaurus.config to reflect the branch renaming.
